### PR TITLE
fix: Enable typescript to locate the module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 
-declare module "vue-konva" {
+declare module "vue3-konva" {
   import {PluginFunction, PluginObject} from 'vue';
   const konvaPlugin: PluginObject<{}> | PluginFunction<{}>;
   export default konvaPlugin;


### PR DESCRIPTION
Currently there is a problem with typescript and resolution of package due to mismatch in name of package and type declared